### PR TITLE
Rework UI in previewView #26

### DIFF
--- a/app/src/main/java/com/mrxx0/easycamera/data/repository/EasyCameraRepositoryImplementation.kt
+++ b/app/src/main/java/com/mrxx0/easycamera/data/repository/EasyCameraRepositoryImplementation.kt
@@ -1,13 +1,9 @@
 package com.mrxx0.easycamera.data.repository
 
 import android.annotation.SuppressLint
-import android.content.ContentValues
 import android.content.Context
 import android.hardware.camera2.CaptureRequest
 import android.net.Uri
-import android.os.Build
-import android.provider.MediaStore
-import android.util.Log
 import android.util.Range
 import android.view.ScaleGestureDetector
 import androidx.annotation.OptIn
@@ -18,30 +14,19 @@ import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageCapture
-import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.Preview
-import androidx.camera.core.resolutionselector.AspectRatioStrategy
-import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.video.FallbackStrategy
-import androidx.camera.video.MediaStoreOutputOptions
 import androidx.camera.video.Quality
-import androidx.camera.video.QualitySelector
 import androidx.camera.video.Recorder
 import androidx.camera.video.Recording
 import androidx.camera.video.VideoCapture
-import androidx.camera.video.VideoRecordEvent
 import androidx.camera.view.PreviewView
 import androidx.compose.runtime.MutableState
-import androidx.core.content.ContextCompat
-import androidx.core.content.PermissionChecker
 import androidx.lifecycle.LifecycleOwner
+import com.mrxx0.easycamera.presentation.viewmodel.ImageSettingsViewModel
+import com.mrxx0.easycamera.presentation.viewmodel.VideoSettingsViewModel
 import com.mrxx0.easycamera.domain.repository.EasyCameraRepository
 import com.mrxx0.easycamera.presentation.viewmodel.MainViewModel
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 class EasyCameraRepositoryImplementation @Inject constructor(
@@ -50,11 +35,13 @@ class EasyCameraRepositoryImplementation @Inject constructor(
     private var cameraPreview: Preview,
     private var imageCapture: ImageCapture,
     private var videoCapture: VideoCapture<Recorder>,
-    private var recording: Recording?,
+    recording: Recording?,
     private val imageAnalysis: ImageAnalysis,
 ) : EasyCameraRepository {
 
     private var camControl : Camera? = null
+    private val imageCamera = ImageSettingsViewModel()
+    private val videoCamera = VideoSettingsViewModel(recording)
 
     @SuppressLint("ClickableViewAccessibility")
     override suspend fun showCameraPreview(
@@ -63,34 +50,22 @@ class EasyCameraRepositoryImplementation @Inject constructor(
         context: Context
     ) {
         cameraPreview.setSurfaceProvider(previewView.surfaceProvider)
-        try {
-            cameraProvider.unbindAll()
-            cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
-            camControl = cameraProvider.bindToLifecycle(
-                lifecycleOwner,
-                cameraSelector,
-                cameraPreview,
-                imageCapture,
-            )
+        cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+        updateImageCameraUseCase(lifecycleOwner)
+        val listener = object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
+            override fun onScale(detector: ScaleGestureDetector): Boolean {
+                val currentZoomRatio = camControl?.cameraInfo?.zoomState?.value?.zoomRatio ?: 0f
+                val delta = detector.scaleFactor
 
-            val listener = object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
-                override fun onScale(detector: ScaleGestureDetector): Boolean {
-                    val currentZoomRatio = camControl?.cameraInfo?.zoomState?.value?.zoomRatio ?: 0f
-                    val delta = detector.scaleFactor
-
-                    camControl?.cameraControl?.setZoomRatio(currentZoomRatio * delta)
-                    return true
-                }
+                camControl?.cameraControl?.setZoomRatio(currentZoomRatio * delta)
+                return true
             }
-            val scaleGestureDetector = ScaleGestureDetector(context, listener)
-            previewView.setOnTouchListener {
+        }
+        val scaleGestureDetector = ScaleGestureDetector(context, listener)
+        previewView.setOnTouchListener {
                 _, event ->
-                scaleGestureDetector.onTouchEvent(event)
-                return@setOnTouchListener true
-            }
-
-        } catch (e: Exception) {
-            e.printStackTrace()
+            scaleGestureDetector.onTouchEvent(event)
+            return@setOnTouchListener true
         }
     }
 
@@ -98,26 +73,16 @@ class EasyCameraRepositoryImplementation @Inject constructor(
         lifecycleOwner: LifecycleOwner,
         cameraMode: Boolean
     ) {
-        try {
-            cameraProvider.unbindAll()
-            cameraSelector =
-                if (cameraSelector == CameraSelector.DEFAULT_BACK_CAMERA) {
-                    CameraSelector.DEFAULT_FRONT_CAMERA
-                } else {
-                    CameraSelector.DEFAULT_BACK_CAMERA
-                }
-            camControl = cameraProvider.bindToLifecycle(
-                lifecycleOwner,
-                cameraSelector,
-                cameraPreview,
-                if (cameraMode) {
-                    imageCapture
-                } else {
-                    videoCapture
-                       },
-            )
-        } catch (e: Exception) {
-            e.printStackTrace()
+        cameraSelector =
+            if (cameraSelector == CameraSelector.DEFAULT_BACK_CAMERA) {
+                CameraSelector.DEFAULT_FRONT_CAMERA
+            } else {
+                CameraSelector.DEFAULT_BACK_CAMERA
+            }
+        if (cameraMode) {
+            updateImageCameraUseCase(lifecycleOwner)
+        } else {
+            updateVideoCameraUseCase(lifecycleOwner)
         }
     }
 
@@ -126,117 +91,26 @@ class EasyCameraRepositoryImplementation @Inject constructor(
         lastImageUri: MutableState<Uri?>,
         timerMode: Int
     ) {
-
-        val imageName = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.ENGLISH)
-            .format(System.currentTimeMillis())
-        val contentValues = ContentValues().apply {
-            put(MediaStore.MediaColumns.DISPLAY_NAME, imageName)
-            put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
-            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
-                put(MediaStore.Images.Media.RELATIVE_PATH, "DCIM/Camera")
-            }
+        try {
+            imageCamera.takePicture(
+                context, lastImageUri, imageCapture, timerMode
+            )
+        } catch (e : Exception) {
+            e.printStackTrace()
         }
-        val outputOptions = ImageCapture.OutputFileOptions
-            .Builder(
-                context.contentResolver,
-                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                contentValues
-            )
-            .build()
-        Executors.newSingleThreadScheduledExecutor().schedule({
-            imageCapture.takePicture(
-                outputOptions,
-                ContextCompat.getMainExecutor(context),
-                object : ImageCapture.OnImageSavedCallback {
-                    override fun onError(exception: ImageCaptureException) {
-                        Log.e(
-                            "EasyCamera",
-                            "Photo capture failed: ${exception.message}",
-                            exception
-                        )
-                    }
-
-                    override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
-                        val logMessage = "Photo capture succeeded: ${outputFileResults.savedUri}"
-                        lastImageUri.value = outputFileResults.savedUri!!
-                        Log.d("EasyCamera", logMessage)
-                    }
-                }
-            )
-        }, timerMode.toLong(), TimeUnit.SECONDS)
     }
 
     override suspend fun takeVideo(
         context: Context,
         lastImageUri: MutableState<Uri?>,
-        timerMode: Int,
         viewModel: MainViewModel
     ) {
-        val curRecording = recording
-        if (curRecording != null) {
-            viewModel.videoRecording = false
-            curRecording.stop()
-            recording = null
-            return
-        }
-        val videoName = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.ENGLISH)
-            .format(System.currentTimeMillis())
-
-        val contentValues = ContentValues().apply {
-            put(MediaStore.MediaColumns.DISPLAY_NAME, videoName)
-            put(MediaStore.MediaColumns.MIME_TYPE, "video/mp4")
-            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
-                put(MediaStore.Video.Media.RELATIVE_PATH, "DCIM/Camera")
-            }
-        }
-        val outputOptions = MediaStoreOutputOptions
-            .Builder(context.contentResolver, MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
-            .setContentValues(contentValues)
-            .build()
-        if (!viewModel.videoRecording) {
-
-            viewModel.videoRecording = true
-            recording = videoCapture.output
-                .prepareRecording(context, outputOptions)
-                .apply {
-                    if (PermissionChecker.checkSelfPermission(
-                            context.applicationContext,
-                            android.Manifest.permission.RECORD_AUDIO
-                        ) ==
-                        PermissionChecker.PERMISSION_GRANTED
-                    ) {
-                        withAudioEnabled()
-                    }
-                }
-                .start(ContextCompat.getMainExecutor(context)) { recordEvent ->
-                    when (recordEvent) {
-                        is VideoRecordEvent.Start -> {
-                            viewModel.videoRecording = true
-                        }
-
-                        is VideoRecordEvent.Finalize -> {
-                            if (!recordEvent.hasError()) {
-                                val logMessage =
-                                    "Video capture succeeded: ${recordEvent.outputResults.outputUri}"
-                                lastImageUri.value = recordEvent.outputResults.outputUri
-                                Log.d("EasyCamera", logMessage)
-                                viewModel.videoRecording = false
-                            } else {
-                                recording?.close()
-                                recording = null
-                                viewModel.videoRecording = false
-                                Log.e(
-                                    "EasyCamera",
-                                    "Video capture failed ${recordEvent.error} + ${recordEvent.cause}"
-                                )
-                            }
-                        }
-                    }
-                }
-        } else {
-            viewModel.videoRecording = false
-            recording?.stop()
-            recording = null
+        try {
+            videoCamera.takeVideo(
+                context, lastImageUri, viewModel, videoCapture
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
     }
 
@@ -244,138 +118,76 @@ class EasyCameraRepositoryImplementation @Inject constructor(
         lifecycleOwner: LifecycleOwner,
         aspectRatio: Int
     ) {
-        try {
-            cameraProvider.unbindAll()
-            val newAspectRatioStrategy =
-                AspectRatioStrategy(aspectRatio, AspectRatioStrategy.FALLBACK_RULE_AUTO)
-            imageCapture = ImageCapture.Builder()
-                .setResolutionSelector(
-                    ResolutionSelector.Builder()
-                        .setAspectRatioStrategy(newAspectRatioStrategy)
-                        .build()
-                )
-                .build()
-            cameraProvider.bindToLifecycle(
-                lifecycleOwner,
-                cameraSelector,
-                cameraPreview,
-                imageCapture,
-            )
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+        imageCapture = imageCamera.setAspectRatio(aspectRatio)
+        updateImageCameraUseCase(lifecycleOwner)
+
     }
 
     override suspend fun setImageFlashMode(
         lifecycleOwner: LifecycleOwner,
         flashMode: Int
     ) {
-        try {
-            cameraProvider.unbindAll()
-            imageCapture = ImageCapture.Builder()
-                .setFlashMode(flashMode)
-                .build()
-            cameraProvider.bindToLifecycle(
-                lifecycleOwner,
-                cameraSelector,
-                cameraPreview,
-                imageCapture,
-            )
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+        imageCapture = imageCamera.setFlashMode(flashMode)
+        updateImageCameraUseCase(lifecycleOwner)
     }
 
     override suspend fun imageMode(
         lifecycleOwner: LifecycleOwner
     ) {
-        try {
-            cameraProvider.unbindAll()
-            cameraProvider.bindToLifecycle(
-                lifecycleOwner,
-                cameraSelector,
-                cameraPreview,
-                imageCapture,
-            )
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+        updateImageCameraUseCase(lifecycleOwner)
     }
 
     @OptIn(ExperimentalCamera2Interop::class) override suspend fun videoMode(
         lifecycleOwner: LifecycleOwner
     ) {
-        try {
-            cameraProvider.unbindAll()
-            camControl = cameraProvider.bindToLifecycle(
-                lifecycleOwner,
-                cameraSelector,
-                cameraPreview,
-                videoCapture,
-            )
-            val newControl = Camera2CameraControl.from(camControl!!.cameraControl)
-            newControl.captureRequestOptions = CaptureRequestOptions.Builder().setCaptureRequestOption(
-                CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
-                Range.create(30, 30)
-            )
-                .build()
-
-
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+        updateVideoCameraUseCase(lifecycleOwner)
+        val newControl = Camera2CameraControl.from(camControl!!.cameraControl)
+        newControl.captureRequestOptions = CaptureRequestOptions.Builder().setCaptureRequestOption(
+            CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
+            Range.create(30, 30)
+        )
+            .build()
     }
 
     override suspend fun setVideoResolution(
         lifecycleOwner: LifecycleOwner,
         videoQuality: Quality
     ) {
-        val selector = QualitySelector
-            .from(
-                videoQuality,
-                FallbackStrategy.higherQualityOrLowerThan(Quality.FHD)
-            )
-        val recorder = Recorder.Builder()
-            .setExecutor(Executors.newSingleThreadExecutor())
-            .setQualitySelector(selector)
-            .build()
-        videoCapture = VideoCapture.withOutput(recorder)
-        try {
-            cameraProvider.unbindAll()
-            cameraProvider.bindToLifecycle(
-                lifecycleOwner,
-                cameraSelector,
-                cameraPreview,
-                videoCapture,
-            )
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+        videoCapture = videoCamera.setVideoResolution(videoQuality)
+        updateVideoCameraUseCase(lifecycleOwner)
     }
 
     override suspend fun setVideoFlashMode(
         lifecycleOwner: LifecycleOwner,
         flashMode: Boolean
     ) {
+       videoCamera.setFlash(camControl, flashMode)
+    }
+
+    @OptIn(ExperimentalCamera2Interop::class) override suspend fun setVideoFPS(
+        fpsValue: Int
+    ) {
+        videoCamera.setFps(camControl, fpsValue)
+    }
+
+    private fun updateImageCameraUseCase(
+        lifecycleOwner: LifecycleOwner
+    ) {
         try {
             cameraProvider.unbindAll()
-            val camera = cameraProvider.bindToLifecycle(
+            camControl = cameraProvider.bindToLifecycle(
                 lifecycleOwner,
                 cameraSelector,
                 cameraPreview,
-                videoCapture,
+                imageCapture,
             )
-            if (camera.cameraInfo.hasFlashUnit()) {
-                camera.cameraControl.enableTorch(flashMode)
-            }
         } catch (e: Exception) {
             e.printStackTrace()
         }
     }
 
-    @OptIn(ExperimentalCamera2Interop::class) override suspend fun setVideoFPS(
-        lifecycleOwner: LifecycleOwner,
-        fpsValue: Int
+    private fun updateVideoCameraUseCase(
+        lifecycleOwner: LifecycleOwner
     ) {
         try {
             cameraProvider.unbindAll()
@@ -385,11 +197,6 @@ class EasyCameraRepositoryImplementation @Inject constructor(
                 cameraPreview,
                 videoCapture,
             )
-                val newControl = Camera2CameraControl.from(camControl!!.cameraControl)
-                newControl.captureRequestOptions = CaptureRequestOptions.Builder().setCaptureRequestOption(
-                    CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
-                    Range.create(30, fpsValue)
-                ).build()
         } catch (e: Exception) {
             e.printStackTrace()
         }

--- a/app/src/main/java/com/mrxx0/easycamera/domain/repository/EasyCameraRepository.kt
+++ b/app/src/main/java/com/mrxx0/easycamera/domain/repository/EasyCameraRepository.kt
@@ -27,7 +27,6 @@ interface EasyCameraRepository {
     suspend fun takeVideo(
         context: Context,
         lastImageUri: MutableState<Uri?>,
-        timerMode: Int,
         viewModel: MainViewModel
     )
 
@@ -58,7 +57,6 @@ interface EasyCameraRepository {
     )
 
     suspend fun setVideoFPS(
-        lifecycleOwner: LifecycleOwner,
         fpsValue: Int
     )
 }

--- a/app/src/main/java/com/mrxx0/easycamera/presentation/view/ImageSettings.kt
+++ b/app/src/main/java/com/mrxx0/easycamera/presentation/view/ImageSettings.kt
@@ -27,26 +27,36 @@ import androidx.compose.material.icons.filled.Timer3Select
 import androidx.compose.material.icons.filled.TimerOff
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.LifecycleOwner
-import com.mrxx0.easycamera.presentation.viewmodel.MainViewModel
+import com.mrxx0.easycamera.presentation.viewmodel.ImageSettingsViewModel
 
 @Composable
 fun ImageSettings(
     lifecycleOwner: LifecycleOwner,
-    viewModel: MainViewModel = hiltViewModel()
+    setAspectRatio: (LifecycleOwner, Int) -> Unit,
+    setFlashMode: (LifecycleOwner, Int) -> Unit,
+    setTimerMode: (Int) -> Unit,
+    ratioState: MutableState<ImageSettingsViewModel.RatioState>,
+    flashState: MutableState<ImageSettingsViewModel.FlashState>,
+    timerState: MutableState<ImageSettingsViewModel.TimerState>
 ) {
-    Box(modifier = Modifier
-        .padding(12.dp)
-        .padding(top = 50.dp)
-        .clip(shape = RoundedCornerShape(15.dp))
-        .background(Color.DarkGray),
+
+    Box(
+        modifier = Modifier
+            .padding(12.dp)
+            .padding(top = 50.dp)
+            .clip(shape = RoundedCornerShape(15.dp))
+            .background(Color.DarkGray),
     ) {
 
         Column(
@@ -62,17 +72,22 @@ fun ImageSettings(
             ) {
                 Text("Image", color = Color.White, fontSize = 20.sp)
             }
-            ImageRatioSettings(lifecycleOwner, viewModel)
-            ImageFlashSettings(lifecycleOwner, viewModel)
-            ImageTimerSettings(viewModel)
+            ImageRatioSettings(lifecycleOwner, setAspectRatio, ratioState)
+            ImageFlashSettings(lifecycleOwner, setFlashMode, flashState)
+            ImageTimerSettings(setTimerMode, timerState)
         }
     }
 }
 
 @Composable
 fun ImageTimerSettings(
-    viewModel: MainViewModel
+    setTimerMode: (Int) -> Unit,
+    timerState: MutableState<ImageSettingsViewModel.TimerState>,
 ) {
+    val currentTimer by remember { mutableStateOf(
+        timerState.value
+    ) }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -84,58 +99,75 @@ fun ImageTimerSettings(
         ) {
             Text("Timer", color = MaterialTheme.colors.onPrimary)
             Spacer(modifier = Modifier.fillMaxWidth(fraction = 0.4f))
-            Row (horizontalArrangement = Arrangement.End,
+            Row(
+                horizontalArrangement = Arrangement.End,
 
-            ){
-                Row (
+                ) {
+                Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween
-                ){
+                ) {
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            timerState.value = currentTimer.copy(off = true, three = false, ten = false)
+                            setTimerMode(0)
+                        }
                     ) {
                         Icon(
                             Icons.Default.TimerOff,
                             contentDescription = "Timer Off",
-                            tint = Color.White,
+                            tint = if (timerState.value.off) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                                   },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.timerMode = 0
-                                }
+
                         )
                         Text("Off", color = Color.White)
                     }
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            timerState.value = currentTimer.copy(off = false, three = true, ten = false)
+                            setTimerMode(3)
+                        }
                     ) {
                         Icon(
                             Icons.Default.Timer3Select,
                             contentDescription = "Timer 3s",
-                            tint = Color.White,
+                            tint = if (timerState.value.three) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.timerMode = 3
-                                }
                         )
                         Text("3s", color = Color.White)
                     }
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            timerState.value = currentTimer.copy(off = false, three = false, ten = true)
+                            setTimerMode(10)
+                        }
                     ) {
                         Icon(
                             Icons.Default.Timer10Select,
                             contentDescription = "Timer 10s",
-                            tint = Color.White,
+                            tint = if (timerState.value.ten) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.timerMode = 10
-                                }
                         )
                         Text("10s", color = Color.White)
                     }
@@ -148,8 +180,12 @@ fun ImageTimerSettings(
 @Composable
 fun ImageFlashSettings(
     lifecycleOwner: LifecycleOwner,
-    viewModel: MainViewModel
+    setFlashMode: (LifecycleOwner, Int) -> Unit,
+    flashState: MutableState<ImageSettingsViewModel.FlashState>,
 ) {
+    val currentFlash by remember { mutableStateOf(
+        flashState.value
+    ) }
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -165,64 +201,79 @@ fun ImageFlashSettings(
             Row(
                 horizontalArrangement = Arrangement.SpaceAround
             ) {
-                Row (
+                Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceAround
-                ){
+                ) {
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            flashState.value = currentFlash.copy(flashAuto = true, flashOn = false, flashOff = false)
+                            setFlashMode(
+                                lifecycleOwner,
+                                ImageCapture.FLASH_MODE_AUTO
+                            )
+                        }
                     ) {
                         Icon(
                             Icons.Default.FlashAuto,
                             contentDescription = "Flash Auto",
-                            tint = Color.White,
+                            tint = if (flashState.value.flashAuto) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setFlashMode(
-                                        lifecycleOwner,
-                                        ImageCapture.FLASH_MODE_AUTO
-                                    )
-                                }
                         )
                         Text("Auto", color = Color.White)
                     }
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            flashState.value = currentFlash.copy(flashAuto = false, flashOn = true, flashOff = false)
+                            setFlashMode(
+                                lifecycleOwner,
+                                ImageCapture.FLASH_MODE_ON
+                            )
+                        }
                     ) {
                         Icon(
                             Icons.Default.FlashOn,
                             contentDescription = "Flash On",
-                            tint = Color.White,
+                            tint = if (flashState.value.flashOn) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setFlashMode(
-                                        lifecycleOwner,
-                                        ImageCapture.FLASH_MODE_ON
-                                    )
-                                }
                         )
                         Text("On", color = Color.White)
                     }
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            flashState.value = currentFlash.copy(flashAuto = false, flashOn = false, flashOff = true)
+                            setFlashMode(
+                                lifecycleOwner,
+                                ImageCapture.FLASH_MODE_OFF
+                            )
+                        }
+                        ) {
                         Icon(
                             Icons.Default.FlashOff,
                             contentDescription = "Flash Off",
-                            tint = Color.White,
+                            tint = if (flashState.value.flashOff) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setFlashMode(
-                                        lifecycleOwner,
-                                        ImageCapture.FLASH_MODE_OFF
-                                    )
-                                }
                         )
                         Text("Off", color = Color.White)
                     }
@@ -235,8 +286,13 @@ fun ImageFlashSettings(
 @Composable
 fun ImageRatioSettings(
     lifecycleOwner: LifecycleOwner,
-    viewModel: MainViewModel
+    setAspectRatio: (LifecycleOwner, Int) -> Unit,
+    ratioState: MutableState<ImageSettingsViewModel.RatioState>,
 ) {
+    val currentRatio by remember { mutableStateOf(
+        ratioState.value
+    ) }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -248,49 +304,59 @@ fun ImageRatioSettings(
         ) {
             Text("Ratio", color = MaterialTheme.colors.onPrimary)
             Spacer(modifier = Modifier.fillMaxWidth(fraction = 0.4f))
-
-            Row (
+            Row(
                 horizontalArrangement = Arrangement.End
-            ){
-                Row (
+            ) {
+                Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceAround
-                ){
+                ) {
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            ratioState.value = currentRatio.copy(threeByFour = true, nineBySixteen = false)
+                            setAspectRatio(
+                                lifecycleOwner,
+                                AspectRatio.RATIO_4_3
+                            )
+
+                        }
                     ) {
                         Icon(
                             Icons.Default.AspectRatio,
                             contentDescription = "Crop 3:4",
-                            tint = Color.White,
+                            tint = if (ratioState.value.threeByFour) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setAspectRatio(
-                                        lifecycleOwner,
-                                        AspectRatio.RATIO_4_3
-                                    )
-                                }
                         )
                         Text("3:4", color = Color.White)
                     }
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            ratioState.value = currentRatio.copy(threeByFour = false, nineBySixteen = true)
+                            setAspectRatio(
+                                lifecycleOwner,
+                                AspectRatio.RATIO_16_9
+                            )
+                        }
                     ) {
                         Icon(
                             Icons.Default.AspectRatio,
                             contentDescription = "Crop 9:16",
-                            tint = Color.White,
+                            tint = if ( ratioState.value.nineBySixteen) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setAspectRatio(
-                                        lifecycleOwner,
-                                        AspectRatio.RATIO_16_9
-                                    )
-                                }
                         )
                         Text("9:16", color = Color.White)
                     }

--- a/app/src/main/java/com/mrxx0/easycamera/presentation/view/SettingsCard.kt
+++ b/app/src/main/java/com/mrxx0/easycamera/presentation/view/SettingsCard.kt
@@ -1,21 +1,38 @@
 package com.mrxx0.easycamera.presentation.view
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.unit.Dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.LifecycleOwner
+import com.mrxx0.easycamera.presentation.viewmodel.ImageSettingsViewModel
+import com.mrxx0.easycamera.presentation.viewmodel.VideoSettingsViewModel
 import com.mrxx0.easycamera.presentation.viewmodel.MainViewModel
 
 @Composable
 fun SettingsCard(
-    screeHeight: Dp,
     lifecycleOwner: LifecycleOwner,
-    viewModel: MainViewModel = hiltViewModel()
-
+    mainViewModel: MainViewModel = hiltViewModel(),
+    videoSettingsViewModel: VideoSettingsViewModel = hiltViewModel(),
+    imageSettingsViewModel: ImageSettingsViewModel = hiltViewModel()
 ) {
-    if (viewModel.getMode()) {
-        ImageSettings(lifecycleOwner)
+    if (mainViewModel.getMode()) {
+        ImageSettings(
+            lifecycleOwner,
+            mainViewModel::setAspectRatio,
+            mainViewModel::setFlashMode,
+            mainViewModel::setTimerMode,
+            imageSettingsViewModel.ratioState,
+            imageSettingsViewModel.flashState,
+            imageSettingsViewModel.timerState
+        )
     } else {
-        VideoSettings(lifecycleOwner)
+        VideoSettings(
+            lifecycleOwner,
+            mainViewModel::setVideoFlash,
+            mainViewModel::setFpsValue,
+            mainViewModel::setVideoQuality,
+            videoSettingsViewModel.fpsState,
+            videoSettingsViewModel.qualityState,
+            videoSettingsViewModel.flashState
+        )
     }
 }

--- a/app/src/main/java/com/mrxx0/easycamera/presentation/view/VideoSettings.kt
+++ b/app/src/main/java/com/mrxx0/easycamera/presentation/view/VideoSettings.kt
@@ -17,32 +17,41 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesomeMotion
 import androidx.compose.material.icons.filled.FlashOff
 import androidx.compose.material.icons.filled.FlashOn
-import androidx.compose.material.icons.twotone.AutoAwesomeMotion
-import androidx.compose.material.icons.twotone.Hd
+import androidx.compose.material.icons.filled.Hd
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.LifecycleOwner
-import com.mrxx0.easycamera.presentation.viewmodel.MainViewModel
+import com.mrxx0.easycamera.presentation.viewmodel.VideoSettingsViewModel
 
 @Composable
 fun VideoSettings(
     lifecycleOwner: LifecycleOwner,
-    viewModel: MainViewModel = hiltViewModel()
+    setVideoFlash: (LifecycleOwner, Boolean) -> Unit,
+    setFpsValue: (Int) -> Unit,
+    setVideoQuality: (LifecycleOwner, Quality) -> Unit,
+    fpsState: MutableState<VideoSettingsViewModel.FpsState>,
+    qualityState: MutableState<VideoSettingsViewModel.QualityState>,
+    flashState: MutableState<VideoSettingsViewModel.FlashState>,
 ) {
-    Box(modifier = Modifier
-        .padding(12.dp)
-        .padding(top = 50.dp)
-        .clip(shape = RoundedCornerShape(15.dp))
-        .background(Color.DarkGray),
+    Box(
+        modifier = Modifier
+            .padding(12.dp)
+            .padding(top = 50.dp)
+            .clip(shape = RoundedCornerShape(15.dp))
+            .background(Color.DarkGray),
     ) {
         Column(
             modifier = Modifier
@@ -57,9 +66,9 @@ fun VideoSettings(
             ) {
                 Text("Video", color = Color.White, fontSize = 20.sp)
             }
-            VideoFpsSettings(lifecycleOwner, viewModel)
-            VideoQualitySettings(lifecycleOwner, viewModel)
-            VideoFlashSettings(lifecycleOwner, viewModel)
+            VideoFpsSettings(setFpsValue, fpsState)
+            VideoQualitySettings(lifecycleOwner, setVideoQuality, qualityState)
+            VideoFlashSettings(lifecycleOwner, setVideoFlash, flashState)
         }
     }
 }
@@ -67,8 +76,14 @@ fun VideoSettings(
 @Composable
 fun VideoFlashSettings(
     lifecycleOwner: LifecycleOwner,
-    viewModel: MainViewModel
+    setVideoFlash: (LifecycleOwner, Boolean) -> Unit,
+    flashState: MutableState<VideoSettingsViewModel.FlashState>
 ) {
+    val currentFlash by remember {
+        mutableStateOf(
+            flashState.value
+        )
+    }
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -84,45 +99,55 @@ fun VideoFlashSettings(
             Row(
                 horizontalArrangement = Arrangement.SpaceAround
             ) {
-                Row (
+                Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceAround
-                ){
+                ) {
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            flashState.value = currentFlash.copy(off = false, on = true)
+                            setVideoFlash(
+                                lifecycleOwner,
+                                true
+                            )
+                        }
                     ) {
                         Icon(
                             Icons.Default.FlashOn,
                             contentDescription = "Flash On",
-                            tint = Color.White,
+                            tint = if (flashState.value.on) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setVideoFlash(
-                                        lifecycleOwner,
-                                        true
-                                    )
-                                }
                         )
                         Text("On", color = Color.White)
                     }
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            flashState.value = currentFlash.copy(off = true, on = false)
+                            setVideoFlash(
+                                lifecycleOwner,
+                                false
+                            )
+                        }
                     ) {
                         Icon(
                             Icons.Default.FlashOff,
                             contentDescription = "Flash Off",
-                            tint = Color.White,
+                            tint = if (flashState.value.off) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setVideoFlash(
-                                        lifecycleOwner,
-                                        false
-                                    )
-                                }
                         )
                         Text("Off", color = Color.White)
                     }
@@ -134,9 +159,16 @@ fun VideoFlashSettings(
 
 @Composable
 fun VideoFpsSettings(
-    lifecycleOwner: LifecycleOwner,
-    viewModel: MainViewModel
+    setFpsValue: (Int) -> Unit,
+    fpsState: MutableState<VideoSettingsViewModel.FpsState>
 ) {
+
+    val currentFps by remember {
+        mutableStateOf(
+            fpsState.value
+        )
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -149,48 +181,57 @@ fun VideoFpsSettings(
             Text("Frame/sec", color = MaterialTheme.colors.onPrimary)
             Spacer(modifier = Modifier.fillMaxWidth(fraction = 0.4f))
 
-            Row (
+            Row(
                 horizontalArrangement = Arrangement.End
-            ){
-                Row (
+            ) {
+                Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceAround
-                ){
+                ) {
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            fpsState.value = currentFps.copy(sixty = true, thirty = false)
+                            setFpsValue(
+                                60
+                            )
+                        }
                     ) {
                         Icon(
-                            Icons.TwoTone.AutoAwesomeMotion,
+                            Icons.Default.AutoAwesomeMotion,
                             contentDescription = "60fps",
-                            tint = Color.White,
+                            tint = if (fpsState.value.sixty) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setFpsValue(
-                                        lifecycleOwner,
-                                        60
-                                    )
-                                }
+
                         )
                         Text("60 fps", color = Color.White)
                     }
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            fpsState.value = currentFps.copy(sixty = false, thirty = true)
+                            setFpsValue(
+                                30
+                            )
+                        }
                     ) {
                         Icon(
-                            Icons.TwoTone.AutoAwesomeMotion,
+                            Icons.Default.AutoAwesomeMotion,
                             contentDescription = "30fps",
-                            tint = Color.White,
+                            tint = if (fpsState.value.thirty) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setFpsValue(
-                                        lifecycleOwner,
-                                        30
-                                    )
-                                }
                         )
                         Text("30 fps", color = Color.White)
                     }
@@ -204,8 +245,14 @@ fun VideoFpsSettings(
 @Composable
 fun VideoQualitySettings(
     lifecycleOwner: LifecycleOwner,
-    viewModel: MainViewModel
+    setVideoQuality: (LifecycleOwner, Quality) -> Unit,
+    qualityState: MutableState<VideoSettingsViewModel.QualityState>
 ) {
+    val currentQuality by remember {
+        mutableStateOf(
+            qualityState.value
+        )
+    }
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -218,58 +265,76 @@ fun VideoQualitySettings(
             Text("Quality", color = MaterialTheme.colors.onPrimary)
             Spacer(modifier = Modifier.fillMaxWidth(fraction = 0.4f))
 
-            Row (
+            Row(
                 horizontalArrangement = Arrangement.End
-            ){
-                Row (
+            ) {
+                Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceAround
-                ){
+                ) {
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            qualityState.value =
+                                currentQuality.copy(ultraHd = true, fullHd = false, hd = false)
+                            setVideoQuality(lifecycleOwner, Quality.UHD)
+                        }
                     ) {
                         Icon(
-                            Icons.TwoTone.Hd,
+                            Icons.Default.Hd,
                             contentDescription = "4k",
-                            tint = Color.White,
+                            tint = if (qualityState.value.ultraHd) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setVideoQuality(lifecycleOwner, Quality.UHD)
-                                }
                         )
                         Text("4K", color = Color.White)
                     }
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            qualityState.value =
+                                currentQuality.copy(ultraHd = false, fullHd = true, hd = false)
+                            setVideoQuality(lifecycleOwner, Quality.FHD)
+                        }
                     ) {
                         Icon(
-                            Icons.TwoTone.Hd,
+                            Icons.Default.Hd,
                             contentDescription = "1080p",
-                            tint = Color.White,
+                            tint = if (qualityState.value.fullHd) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setVideoQuality(lifecycleOwner, Quality.FHD)
-                                }
                         )
                         Text("1080p", color = Color.White)
                     }
                     Column(
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.clickable {
+                            qualityState.value =
+                                currentQuality.copy(ultraHd = false, fullHd = false, hd = true)
+                            setVideoQuality(lifecycleOwner, Quality.HD)
+                        }
                     ) {
                         Icon(
-                            Icons.TwoTone.Hd,
+                            Icons.Default.Hd,
                             contentDescription = "720p",
-                            tint = Color.White,
+                            tint = if (qualityState.value.hd) {
+                                Color.Blue
+                            } else {
+                                Color.White
+                            },
                             modifier = Modifier
                                 .size(38.dp)
-                                .clickable {
-                                    viewModel.setVideoQuality(lifecycleOwner, Quality.HD)
-                                }
                         )
                         Text("720p", color = Color.White)
                     }

--- a/app/src/main/java/com/mrxx0/easycamera/presentation/viewmodel/ImageSettingsViewModel.kt
+++ b/app/src/main/java/com/mrxx0/easycamera/presentation/viewmodel/ImageSettingsViewModel.kt
@@ -1,0 +1,134 @@
+package com.mrxx0.easycamera.presentation.viewmodel
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.util.Log
+import androidx.camera.core.AspectRatio
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.resolutionselector.AspectRatioStrategy
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+@HiltViewModel
+class ImageSettingsViewModel @Inject constructor() : ViewModel() {
+
+    private var flash = mutableIntStateOf(ImageCapture.FLASH_MODE_AUTO)
+    var flashState = mutableStateOf(FlashState(flashAuto = true, flashOff = false, flashOn = false))
+
+    private var ratio = mutableIntStateOf(AspectRatio.RATIO_4_3)
+    var ratioState = mutableStateOf(RatioState(threeByFour = true, nineBySixteen = false))
+
+    var timerState = mutableStateOf(TimerState(off = true, three = false, ten = false))
+
+    fun takePicture(
+        context: Context,
+        lastImageUri: MutableState<Uri?>,
+        imageCapture: ImageCapture,
+        timerMode: Int
+    ) {
+        val imageName = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.ENGLISH)
+            .format(System.currentTimeMillis())
+        val contentValues = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, imageName)
+            put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+                put(MediaStore.Images.Media.RELATIVE_PATH, "DCIM/Camera")
+            }
+        }
+        val outputOptions = ImageCapture.OutputFileOptions
+            .Builder(
+                context.contentResolver,
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                contentValues
+            )
+            .build()
+        Executors.newSingleThreadScheduledExecutor().schedule({
+            imageCapture.takePicture(
+                outputOptions,
+                ContextCompat.getMainExecutor(context),
+                object : ImageCapture.OnImageSavedCallback {
+                    override fun onError(exception: ImageCaptureException) {
+                        Log.e(
+                            "EasyCamera",
+                            "Photo capture failed: ${exception.message}",
+                            exception
+                        )
+                    }
+
+                    override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
+                        val logMessage = "Photo capture succeeded: ${outputFileResults.savedUri}"
+                        lastImageUri.value = outputFileResults.savedUri!!
+                        Log.d("EasyCamera", logMessage)
+                    }
+                }
+            )
+        }, timerMode.toLong(), TimeUnit.SECONDS)
+    }
+
+    fun setAspectRatio(
+        aspectRatio: Int,
+    ): ImageCapture {
+
+        ratio.intValue = aspectRatio
+        val newAspectRatioStrategy =
+            AspectRatioStrategy(aspectRatio, AspectRatioStrategy.FALLBACK_RULE_AUTO)
+        return ImageCapture.Builder()
+            .setResolutionSelector(
+                ResolutionSelector.Builder()
+                    .setAspectRatioStrategy(newAspectRatioStrategy)
+                    .build()
+            )
+            .setFlashMode(flash.intValue)
+            .build()
+    }
+
+    fun setFlashMode(
+        flashMode: Int,
+    ): ImageCapture {
+
+        flash.intValue = flashMode
+        val currentRatio = ratio.intValue
+        return ImageCapture.Builder()
+            .setFlashMode(flashMode)
+            .setResolutionSelector(
+                ResolutionSelector.Builder()
+                    .setAspectRatioStrategy(
+                        AspectRatioStrategy(
+                            currentRatio,
+                            AspectRatioStrategy.FALLBACK_RULE_AUTO
+                        )
+                    )
+                    .build()
+            )
+            .build()
+    }
+
+    data class RatioState(
+        var threeByFour: Boolean ,
+        var nineBySixteen: Boolean
+    )
+    data class FlashState (
+        var flashAuto: Boolean,
+        var flashOn : Boolean,
+        var flashOff : Boolean
+    )
+    data class TimerState(
+        var off: Boolean,
+        var three: Boolean,
+        var ten: Boolean
+    )
+}

--- a/app/src/main/java/com/mrxx0/easycamera/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/mrxx0/easycamera/presentation/viewmodel/MainViewModel.kt
@@ -26,8 +26,9 @@ class MainViewModel @Inject constructor(
 ):ViewModel() {
 
     var cameraMode = true
-    var timerMode = 0
     var videoRecording = false
+
+    var mainTimer = 0
 
     fun getMode() : Boolean {
         return cameraMode
@@ -36,6 +37,11 @@ class MainViewModel @Inject constructor(
         cameraMode = mode
     }
 
+    fun setTimerMode(
+        newTimer: Int
+    ) {
+        mainTimer = newTimer
+    }
     fun showCameraPreview(
         previewView: PreviewView,
         lifecycleOwner: LifecycleOwner,
@@ -77,14 +83,12 @@ class MainViewModel @Inject constructor(
     fun takeVideo(
         context: Context,
         lastImageUri: MutableState<Uri?>,
-        timerMode: Int,
         viewModel: MainViewModel
     ) {
         viewModelScope.launch {
             cameraRepository.takeVideo(
                 context,
                 lastImageUri,
-                timerMode,
                 viewModel
             )
         }
@@ -195,12 +199,10 @@ class MainViewModel @Inject constructor(
     }
 
     fun setFpsValue(
-        lifecycleOwner: LifecycleOwner,
         fpsValue: Int
     ) {
         viewModelScope.launch {
             cameraRepository.setVideoFPS(
-                lifecycleOwner,
                 fpsValue
             )
         }

--- a/app/src/main/java/com/mrxx0/easycamera/presentation/viewmodel/VideoSettingsViewModel.kt
+++ b/app/src/main/java/com/mrxx0/easycamera/presentation/viewmodel/VideoSettingsViewModel.kt
@@ -1,0 +1,176 @@
+package com.mrxx0.easycamera.presentation.viewmodel
+
+import android.content.ContentValues
+import android.content.Context
+import android.hardware.camera2.CaptureRequest
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.util.Log
+import android.util.Range
+import androidx.annotation.OptIn
+import androidx.camera.camera2.interop.Camera2CameraControl
+import androidx.camera.camera2.interop.CaptureRequestOptions
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop
+import androidx.camera.core.Camera
+import androidx.camera.video.FallbackStrategy
+import androidx.camera.video.MediaStoreOutputOptions
+import androidx.camera.video.Quality
+import androidx.camera.video.QualitySelector
+import androidx.camera.video.Recorder
+import androidx.camera.video.Recording
+import androidx.camera.video.VideoCapture
+import androidx.camera.video.VideoRecordEvent
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.core.content.ContextCompat
+import androidx.core.content.PermissionChecker
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.concurrent.Executors
+import javax.inject.Inject
+
+@HiltViewModel
+class VideoSettingsViewModel @Inject constructor(
+    private var recording: Recording?
+) : ViewModel() {
+
+    private var fps = mutableIntStateOf(30)
+    var fpsState = mutableStateOf(FpsState(sixty = false, thirty = true))
+
+    private var quality = mutableStateOf(Quality.FHD)
+    var qualityState = mutableStateOf(QualityState(ultraHd = false, fullHd = true, hd = false))
+
+    private var flash = mutableStateOf(false)
+    var flashState = mutableStateOf(FlashState(off = true, on = false))
+
+
+    fun takeVideo(
+        context: Context,
+        lastImageUri: MutableState<Uri?>,
+        viewModel: MainViewModel,
+        videoCapture: VideoCapture<Recorder>,
+    ) {
+        val curRecording = recording
+        if (curRecording != null) {
+            viewModel.videoRecording = false
+            curRecording.stop()
+            recording = null
+            return
+        }
+        val videoName = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.ENGLISH)
+            .format(System.currentTimeMillis())
+
+        val contentValues = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, videoName)
+            put(MediaStore.MediaColumns.MIME_TYPE, "video/mp4")
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+                put(MediaStore.Video.Media.RELATIVE_PATH, "DCIM/Camera")
+            }
+        }
+        val outputOptions = MediaStoreOutputOptions
+            .Builder(context.contentResolver, MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
+            .setContentValues(contentValues)
+            .build()
+        if (!viewModel.videoRecording) {
+
+            viewModel.videoRecording = true
+            recording = videoCapture.output
+                .prepareRecording(context, outputOptions)
+                .apply {
+                    if (PermissionChecker.checkSelfPermission(
+                            context.applicationContext,
+                            android.Manifest.permission.RECORD_AUDIO
+                        ) ==
+                        PermissionChecker.PERMISSION_GRANTED
+                    ) {
+                        withAudioEnabled()
+                    }
+                }
+                .start(ContextCompat.getMainExecutor(context)) { recordEvent ->
+                    when (recordEvent) {
+                        is VideoRecordEvent.Start -> {
+                            viewModel.videoRecording = true
+                        }
+
+                        is VideoRecordEvent.Finalize -> {
+                            if (!recordEvent.hasError()) {
+                                val logMessage =
+                                    "Video capture succeeded: ${recordEvent.outputResults.outputUri}"
+                                lastImageUri.value = recordEvent.outputResults.outputUri
+                                Log.d("EasyCamera", logMessage)
+                                viewModel.videoRecording = false
+                            } else {
+                                recording?.close()
+                                recording = null
+                                viewModel.videoRecording = false
+                                Log.e(
+                                    "EasyCamera",
+                                    "Video capture failed ${recordEvent.error} + ${recordEvent.cause}"
+                                )
+                            }
+                        }
+                    }
+                }
+        } else {
+            viewModel.videoRecording = false
+            recording?.stop()
+            recording = null
+        }
+    }
+
+    fun setVideoResolution(
+        videoQuality: Quality
+    ): VideoCapture<Recorder> {
+        quality.value = videoQuality
+        val selector = QualitySelector
+            .from(
+                quality.value,
+                FallbackStrategy.higherQualityOrLowerThan(Quality.FHD)
+            )
+        val recorder = Recorder.Builder()
+            .setExecutor(Executors.newSingleThreadExecutor())
+            .setQualitySelector(selector)
+            .build()
+        return (VideoCapture.withOutput(recorder))
+    }
+
+    fun setFlash(
+        cameraControl: Camera?,
+        flashMode: Boolean
+    ) {
+        if (cameraControl?.cameraInfo?.hasFlashUnit() == true) {
+            flash.value = flashMode
+            cameraControl.cameraControl.enableTorch(flash.value)
+        }
+    }
+    @OptIn(ExperimentalCamera2Interop::class)
+    fun setFps(
+        cameraControl: Camera?,
+        fpsValue: Int
+    ) {
+        fps.intValue = fpsValue
+        val newControl = Camera2CameraControl.from(cameraControl!!.cameraControl)
+        newControl.captureRequestOptions = CaptureRequestOptions.Builder().setCaptureRequestOption(
+            CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
+            Range.create(30, fps.intValue)
+        ).build()
+    }
+
+    data class FpsState(
+        var sixty: Boolean ,
+        var thirty: Boolean
+    )
+    data class QualityState (
+        var ultraHd: Boolean,
+        var fullHd : Boolean,
+        var hd : Boolean
+    )
+    data class FlashState(
+        var off: Boolean,
+        var on: Boolean
+    )
+}


### PR DESCRIPTION
- Create 2 viewModel for ImageSettings and VideoSettings
- Rework the logic and UI/UX in settings card both Image and Video :
	- ImageSettings Card by using 3 data class (Flash, Ratio, and Timer) to manage each settings with granularity
	- Same for VideoSettings with 3 data class (Flash, Fps, and Quality)
- Move camera functions to their appropriate viewModel (Image/Video) instead of putting them in the mainViewModel
- In mainViewModel create 2 functions to update cameraUseCase depending on the actual camera mode (image or video)
- Refactor prototype of image and video settings by using strict functions only instead of entire viewModel in Image and Video settings UI